### PR TITLE
Outlines exclude x-axis (restore #478)

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -447,8 +447,8 @@ export default class WebAudio extends util.Observer {
             for (i = first; i <= last; i++) {
                 const start = ~~(i * sampleSize);
                 const end = ~~(start + sampleSize);
-                let min = 0;
-                let max = 0;
+                let min = chan[start];
+                let max = min;
                 let j;
 
                 for (j = start; j < end; j += sampleStep) {


### PR DESCRIPTION
In my original mod #478 the waveform min and max were initialized with the first sample, so that a min > 0 or a max < 0 were possible (e.g. for highly zoomed-in views).  This got lost somewhere along the way; this change fixes it.

# Hey, thank you for contributing to wavesurfer.js!

To review/merge open PRs it is very helpful to know as much as possible about the changes which are being introduced. Reviewing PRs is very time consuming, please be patient, it can take some time to do properly.

**Title:** Please make sure the name of your PR is as descriptive as possible (Describe the feature that is introduced or the bug that is being fixed).

## Please make sure you provide the information below:

### Short description of changes:
Waveform outlines no longer include 0 sample (x-axis).  This is particularly important for highly zoomed-in views.  Before this change, a highly-zoomed-in waveform might look like:
![image](https://user-images.githubusercontent.com/552145/81504809-5a4fb680-92b9-11ea-8718-83ab6f26f18e.png)
(where the amplitude=0 point is included at every time).  With this change, it looks more like:
![image](https://user-images.githubusercontent.com/552145/81504823-72bfd100-92b9-11ea-8504-ec80632cb632.png)
(where the actual waveform is drawn).

Thanks to alimatinfar1376@gmail.com for drawing my attention to this problem.


### Breaking in the external API:
None.  Visual appearance of waveforms change when highly zoomed-in.

### Breaking changes in the internal API:
None.

### Todos/Notes:


### Related Issues and other PRs:
I added the ability to follow the detail in zoomed-in waveforms in #478.  This was regressed by nathansnider soon afterwards in https://github.com/katspaugh/wavesurfer.js/commit/46e6eddb65999f0d7b4c1726de25c842c481072c#diff-268e184f68ebebc7a4772c6e3a47c2ab , but I'm not clear if the change was actually breaking something.  I believe a display that doesn't arbitrarily render the waveform as connected to zero is preferable, but I don't understand why nathansnider made the change (and he's no longer active on GitHub).
